### PR TITLE
Add <releases> to appdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,8 @@ D-Feet is an easy to use D-Bus debugger. D-Feet can be used to inspect D-Bus int
 
 ## Notes
 
-* `0001-Rename-the-icons-appdata-and-desktop-files.patch`,
-  `0003-build-Install-appstream-metadata-to-non-deprecated-l.patch`,
-  `0004-Do-not-use-hyphen-for-the-reverse-DNS-names.patch`:
-  already merged upstream. We use `"rm-configure": true` in the manifest to
-  cause `autogen.sh` to be re-run.
-* `0005-Set-icon_name-to-org.gnome.dfeet.patch`: already merged upstream.
+* `appdata-add-OARS-metadata.patch`: already merged upstream
+* `appdata-add-releases-with-0.3.14-release-date.patch`: analogous change [submitted upstream](https://gitlab.gnome.org/GNOME/d-feet/merge_requests/21)
 
 ## Credits
 

--- a/appdata-add-releases-with-0.3.14-release-date.patch
+++ b/appdata-add-releases-with-0.3.14-release-date.patch
@@ -1,0 +1,27 @@
+From 4512e90e6103ac930edb4b4f76c4525db7a64fda Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Tue, 6 Aug 2019 15:04:16 +0100
+Subject: [PATCH] appdata: add <releases> with 0.3.14 release date
+
+Not submitted upstream; notes for the forthcoming 0.3.15 release
+submitted at https://gitlab.gnome.org/GNOME/d-feet/merge_requests/21.
+---
+ data/org.gnome.dfeet.appdata.xml.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/data/org.gnome.dfeet.appdata.xml.in b/data/org.gnome.dfeet.appdata.xml.in
+index 2460a28..18e8541 100644
+--- a/data/org.gnome.dfeet.appdata.xml.in
++++ b/data/org.gnome.dfeet.appdata.xml.in
+@@ -25,4 +25,8 @@
+   <project_group>GNOME</project_group>
+   <translation type="gettext">d-feet</translation>
+   <content_rating type="oars-1.1" />
++
++  <releases>
++    <release version="0.3.14" date="2018-10-24"/>
++  </releases>
+ </component>
+-- 
+2.20.1
+

--- a/org.gnome.dfeet.json
+++ b/org.gnome.dfeet.json
@@ -71,7 +71,10 @@
                 },
                 {
                     "type": "patch",
-                    "path": "appdata-add-OARS-metadata.patch"
+                    "paths": [
+                        "appdata-add-OARS-metadata.patch",
+                        "appdata-add-releases-with-0.3.14-release-date.patch"
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
I merged #3 because I thought `<releases>` was one of the things that is mandatory at PR time but not (yet) at production build time. I was wrong!